### PR TITLE
Debugger support

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -37,7 +37,7 @@
     "clean": "rm -rf ./dist/* && rm -rf ./out/* && rm -rf ./bin/* && rm *.vsix",
     "package": "cp ../README.md ./README.md && npx vsce package --baseContentUrl https://github.com/gnoverse/vscode-gno/raw/HEAD --baseImagesUrl https://github.com/gnoverse/vscode-gno/raw/HEAD",
     "vscode:prepublish": "npm run compile",
-    "bundle": "esbuild src/gnoMain.ts --bundle --outdir=dist --external:vscode --format=cjs --platform=node",
+    "bundle": "esbuild src/gnoMain.ts --bundle --outdir=dist --external:vscode --format=cjs --platform=node --loader:.node=file",
     "bundle-dev": "npm run bundle -- --sourcemap",
     "bundle-watch": "npm run bundle -- --sourcemap --watch",
     "test-compile": "tsc -p ./",
@@ -277,6 +277,135 @@
         "language": "gno"
       }
     ],
+    "debuggers": [
+      {
+        "type": "gno",
+        "label": "Gno Debugger",
+        "program": "./dist/gnoMain.js",
+        "languages": [
+          "gno"
+        ],
+        "configurationSnippets": [
+          {
+            "label": "Gno: Launch Package",
+            "description": "Debug the package in the program attribute",
+            "body": {
+              "name": "${2:Launch Package}",
+              "type": "gno",
+              "request": "launch",
+              "mode": "auto",
+              "program": "${workspaceFolder}${1:}",
+              "stopOnEntry": true
+            }
+          },
+          {
+            "label": "Gno: Launch file",
+            "description": "Debug the file in the program attribute",
+            "body": {
+              "name": "${2:Launch file}",
+              "type": "gno",
+              "request": "launch",
+              "mode": "debug",
+              "program": "${1:${file}}",
+              "stopOnEntry": true
+            }
+          }
+        ],
+        "configurationAttributes": {
+          "launch": {
+            "required": [
+              "program"
+            ],
+            "properties": {
+              "program": {
+                "type": "string",
+                "description": "Path to the program folder or file to debug"
+              },
+              "mode": {
+                "enum": [
+                  "auto",
+                  "debug",
+                  "test"
+                ],
+                "description": "Mode de débogage - auto choisis entre debug/test selon le fichier actif",
+                "default": "auto"
+              },
+              "stopOnEntry": {
+                "type": "boolean",
+                "description": "Automatically stop program after launch",
+                "default": true
+              },
+              "args": {
+                "type": [
+                  "array",
+                  "string"
+                ],
+                "description": "Command line arguments passed to the program",
+                "items": {
+                  "type": "string"
+                },
+                "default": []
+              },
+              "cwd": {
+                "type": "string",
+                "description": "Working directory for the program",
+                "default": "${workspaceFolder}"
+              },
+              "env": {
+                "type": "object",
+                "description": "Environment variables passed to the program",
+                "default": {}
+              },
+              "buildFlags": {
+                "type": [
+                  "string",
+                  "array"
+                ],
+                "description": "Build flags to pass to the gno compiler",
+                "items": {
+                  "type": "string"
+                },
+                "default": []
+              },
+              "showLog": {
+                "type": "boolean",
+                "description": "Show debug adapter logs",
+                "default": false
+              },
+              "logOutput": {
+                "type": "string",
+                "description": "Specify what components should output debug logs",
+                "default": "debugger"
+              },
+              "trace": {
+                "type": "string",
+                "enum": [
+                  "verbose",
+                  "trace",
+                  "log",
+                  "info",
+                  "warn",
+                  "error"
+                ],
+                "default": "error",
+                "description": "Debug adapter logging level"
+              }
+            }
+          }
+        },
+        "initialConfigurations": [
+          {
+            "name": "Debug Gno Package",
+            "type": "gno",
+            "request": "launch",
+            "mode": "auto",
+            "program": "${workspaceFolder}",
+            "env": {},
+            "args": []
+          }
+        ]
+      }
+    ],
     "configuration": {
       "type": "object",
       "title": "Gno",
@@ -289,36 +418,36 @@
         "gno.makeTx": {
           "type": "object",
           "properties": {
-              "broadcast": {
-                  "type": "boolean",
-                  "default": true,
-                  "description": "If true, broadcasts transaction to chain"
-              },
-              "gasFee": {
-                  "type": "string",
-                  "default": "1000000ugnot",
-                  "description": "Gas fee for transaction"
-              },
-              "gasWanted": {
-                  "type": "string",
-                  "default": "2000000",
-                  "description": "Gas wanted for transaction"
-              }
+            "broadcast": {
+              "type": "boolean",
+              "default": true,
+              "description": "If true, broadcasts transaction to chain"
+            },
+            "gasFee": {
+              "type": "string",
+              "default": "1000000ugnot",
+              "description": "Gas fee for transaction"
+            },
+            "gasWanted": {
+              "type": "string",
+              "default": "2000000",
+              "description": "Gas wanted for transaction"
+            }
           },
           "additionalProperties": false,
           "default": {
-              "broadcast": true,
-              "gasFee": "1000000ugnot",
-              "gasWanted": "4000000"
+            "broadcast": true,
+            "gasFee": "1000000ugnot",
+            "gasWanted": "4000000"
           },
           "description": "Configuration for Gno blockchain transactions",
           "scope": "resource"
-      },
-      "gno.editorContextMenuCommands.addPackage": {
+        },
+        "gno.editorContextMenuCommands.addPackage": {
           "type": "boolean",
           "default": true,
           "description": "If true, adds command to add package to the Gno blockchain to the editor context menu"
-      },
+        },
         "gno.disableConcurrentTests": {
           "type": "boolean",
           "default": false,

--- a/extension/src/debugAdapter/gnoDebug.ts
+++ b/extension/src/debugAdapter/gnoDebug.ts
@@ -1,0 +1,46 @@
+//import * as vscode from vscode;
+import {
+	DebugSession,
+	InitializedEvent,
+	TerminatedEvent,
+	StoppedEvent,
+	LoggingDebugSession
+} from 'vscode-debugadapter';
+
+import { DebugProtocol } from 'vscode-debugprotocol';
+
+interface GnoLaunchRequestArguments extends DebugProtocol.LaunchRequestArguments {
+	program: string; // path gno for debug
+}
+
+
+class GnoDebugSession extends LoggingDebugSession {
+	public constructor() {
+		super("gno-debug.txt");
+
+		this.setDebuggerLinesStartAt1(true);
+		this.setDebuggerColumnsStartAt1(true);
+	}
+
+	protected initializeRequest(response: DebugProtocol.InitializeResponse, args: DebugProtocol.InitializeRequestArguments): void {
+		response.body = response.body || {};
+		response.body.supportsConfigurationDoneRequest = true;
+		this.sendResponse(response);
+		this.sendEvent(new InitializedEvent());
+	}
+
+	protected setBreakPointsRequest(response: DebugProtocol.SetBreakpointsResponse, args: DebugProtocol.SetBreakpointsArguments, request?: DebugProtocol.Request): void {
+		response.body = {
+			breakpoints: []
+		};
+		this.sendResponse(response);
+	}
+
+	protected launchRequest(response: DebugProtocol.LaunchResponse, args: GnoLaunchRequestArguments, request?: DebugProtocol.Request): void {
+		const programPath = args.program;
+		console.log(`Launch gno program : ${programPath}`);
+		this.sendResponse(response);
+	}
+}
+
+GnoDebugSession.run(GnoDebugSession);

--- a/extension/src/debugAdapter/gnoDebug.ts
+++ b/extension/src/debugAdapter/gnoDebug.ts
@@ -1,46 +1,351 @@
-//import * as vscode from vscode;
+import { EventEmitter } from "events";
+import * as fs from 'fs';
+import { spawn, ChildProcess } from 'child_process';
+import * as path from 'path';
 import {
-	DebugSession,
-	InitializedEvent,
-	TerminatedEvent,
-	StoppedEvent,
-	LoggingDebugSession
+    DebugSession,
+    InitializedEvent,
+    TerminatedEvent,
+    StoppedEvent,
+    Breakpoint,
+    Thread,
+    Scope,
+    OutputEvent
 } from 'vscode-debugadapter';
-
 import { DebugProtocol } from 'vscode-debugprotocol';
 
-interface GnoLaunchRequestArguments extends DebugProtocol.LaunchRequestArguments {
-	program: string; // path gno for debug
+// Client that handles communication with the Gno debugger process
+export class GnoDebuggerClient extends EventEmitter {
+    private proc: ChildProcess;
+    private outputBuffer: string = "";
+    private waitingResolve: ((value: string) => void) | null = null;
+    private readonly promptText = "bdg>";
+
+    constructor(private program: string) {
+        super();
+        this.proc = spawn("gno", ["run", "-debug", program], {
+            cwd: process.cwd(),
+            env: process.env
+        });
+
+        this.proc.stdout?.on('data', (data: Buffer) => {
+            this.handleData(data.toString());
+        });
+
+        this.proc.stderr?.on('data', (data: Buffer) => {
+            this.emit("output", data.toString());
+        });
+    }
+
+    // Parses debugger output and resolves pending promises when prompt is detected
+    private handleData(data: string): void {
+        this.emit("output", data);
+
+        this.outputBuffer += data;
+        const trimmedBuffer = this.outputBuffer.trim();
+        const promptIndex = trimmedBuffer.indexOf(this.promptText);
+        if (promptIndex !== -1) {
+            const output = trimmedBuffer.substring(0, promptIndex);
+            this.outputBuffer = trimmedBuffer.substring(promptIndex + this.promptText.length);
+            if (this.waitingResolve) {
+                this.waitingResolve(output.trim());
+                this.waitingResolve = null;
+            }
+        }
+    }
+
+    // Sends commands to the debugger and returns response as promise
+    public sendCommand(command: string): Promise<string> {
+        return new Promise((resolve, reject) => {
+            try {
+                this.waitingResolve = resolve;
+                this.proc.stdin?.write(command + "\n");
+            } catch (error) {
+                reject(error);
+            }
+        });
+    }
+
+    public dispose(): void {
+        this.proc.kill();
+    }
+
+    public async setBreakpoint(line: number): Promise<boolean> {
+        const response = await this.sendCommand(`b ${line}`);
+        return response.toLowerCase().includes('breakpoint');
+    }
+
+    public async getStackTrace(): Promise<{
+        frame: number;
+        function: string;
+        file: string;
+        line: number;
+        column: number;
+    }[]> {
+        const response = await this.sendCommand('stack');
+        return this.parseStackTrace(response);
+    }
+
+    // Parses stack trace output into structured format
+    private parseStackTrace(output: string) {
+        const frames = [];
+        const lines = output.split('\n').filter(l => l.trim());
+        for (let i = 0; i < lines.length - 1; i += 2) {
+            const frameLine = lines[i];
+            const locLine = lines[i + 1];
+            const frameMatch = frameLine.match(/^(\d+)\s+in\s+(.+)$/);
+            const locMatch = locLine.match(/^at\s+(.+):(\d+):(\d+)$/);
+            if (frameMatch && locMatch) {
+                frames.push({
+                    frame: parseInt(frameMatch[1]),
+                    function: frameMatch[2],
+                    file: locMatch[1],
+                    line: parseInt(locMatch[2]),
+                    column: parseInt(locMatch[3]),
+                });
+            }
+        }
+        return frames;
+    }
 }
 
+// Main debug adapter implementation that connects VSCode to the Gno debugger
+export class GnoDebugSession extends DebugSession {
+    private static THREAD_ID = 1;
+    private client: GnoDebuggerClient | undefined;
 
-class GnoDebugSession extends LoggingDebugSession {
-	public constructor() {
-		super("gno-debug.txt");
+    public constructor() {
+        super();
+        this.setDebuggerLinesStartAt1(true);
+        this.setDebuggerColumnsStartAt1(true);
+    }
+    protected async evaluateRequest(
+        response: DebugProtocol.EvaluateResponse,
+        args: DebugProtocol.EvaluateArguments
+    ): Promise<void> {
+        console.log("Evaluate request:", args.expression);
+        if (!this.client) {
+            response.body = { result: "Debugger not initialized", variablesReference: 0 };
+            this.sendResponse(response);
+            return;
+        }
+        try {
+            const output = await this.client.sendCommand(args.expression);
+            response.body = { result: output.trim(), variablesReference: 0 };
+        } catch (error) {
+            response.body = { result: `Error: ${error}`, variablesReference: 0 };
+        }
+        this.sendResponse(response);
+    }
 
-		this.setDebuggerLinesStartAt1(true);
-		this.setDebuggerColumnsStartAt1(true);
-	}
+    // Initializes debug session and declares supported features
+    protected initializeRequest(
+        response: DebugProtocol.InitializeResponse,
+        args: DebugProtocol.InitializeRequestArguments
+    ): void {
+        response.body = response.body || {};
+        response.body.supportsConfigurationDoneRequest = true;
+        response.body.supportsEvaluateForHovers = true;
+        response.body.supportsTerminateRequest = true;
+        response.body.supportTerminateDebuggee = true;
+        response.body.supportsCompletionsRequest = true;
+        this.sendResponse(response);
+        this.sendEvent(new InitializedEvent());
+    }
 
-	protected initializeRequest(response: DebugProtocol.InitializeResponse, args: DebugProtocol.InitializeRequestArguments): void {
-		response.body = response.body || {};
-		response.body.supportsConfigurationDoneRequest = true;
-		this.sendResponse(response);
-		this.sendEvent(new InitializedEvent());
-	}
+    // Launches the debugger process and sets up event handlers
+    protected async launchRequest(
+        response: DebugProtocol.LaunchResponse,
+        args: any
+    ): Promise<void> {
+        try {
+            this.client = new GnoDebuggerClient(args.program);
 
-	protected setBreakPointsRequest(response: DebugProtocol.SetBreakpointsResponse, args: DebugProtocol.SetBreakpointsArguments, request?: DebugProtocol.Request): void {
-		response.body = {
-			breakpoints: []
-		};
-		this.sendResponse(response);
-	}
+            await new Promise<void>((resolve) => {
+                this.client?.on("initialized", () => {
+                    resolve();
+                });
 
-	protected launchRequest(response: DebugProtocol.LaunchResponse, args: GnoLaunchRequestArguments, request?: DebugProtocol.Request): void {
-		const programPath = args.program;
-		console.log(`Launch gno program : ${programPath}`);
-		this.sendResponse(response);
-	}
+                setTimeout(() => {
+                    resolve();
+                }, 5000);
+            });
+
+            this.client.on("output", (data: string) => {
+                this.sendEvent(new OutputEvent(data, "stdout"));
+            });
+
+            this.sendResponse(response);
+            this.sendEvent(new StoppedEvent("entry", GnoDebugSession.THREAD_ID));
+        } catch (error) {
+            console.error("Launch failed:", error);
+            this.sendErrorResponse(response, {
+                id: 1,
+                format: `Failed to launch debugger: ${error}`,
+                showUser: true
+            });
+        }
+    }
+
+    // Handles breakpoint setting and clearing
+    protected async setBreakpointsRequest(
+        response: DebugProtocol.SetBreakpointsResponse,
+        args: DebugProtocol.SetBreakpointsArguments
+    ): Promise<void> {
+        if (!this.client) {
+            response.body = { breakpoints: [] };
+            this.sendResponse(response);
+            return;
+        }
+
+        await this.client.sendCommand("clear");
+        const breakpoints: Breakpoint[] = [];
+
+        if (args.breakpoints) {
+            for (const bp of args.breakpoints) {
+                const success = await this.client.setBreakpoint(bp.line);
+                breakpoints.push(new Breakpoint(success, bp.line));
+            }
+        }
+
+        response.body = { breakpoints };
+        this.sendResponse(response);
+    }
+
+    protected threadsRequest(response: DebugProtocol.ThreadsResponse): void {
+        response.body = { threads: [new Thread(GnoDebugSession.THREAD_ID, "Main Thread")] };
+        this.sendResponse(response);
+    }
+
+    protected async stackTraceRequest(
+        response: DebugProtocol.StackTraceResponse,
+        args: DebugProtocol.StackTraceArguments
+    ): Promise<void> {
+        if (!this.client) {
+            response.body = { stackFrames: [] };
+            this.sendResponse(response);
+            return;
+        }
+
+        try {
+            const stackFrames = await this.client.getStackTrace();
+            response.body = {
+                stackFrames: stackFrames.map(f => ({
+                    id: f.frame,
+                    name: f.function,
+                    source: {
+                        name: path.basename(f.file),
+                        path: f.file
+                    },
+                    line: f.line,
+                    column: f.column
+                })),
+                totalFrames: stackFrames.length
+            };
+        } catch (error) {
+            response.body = { stackFrames: [] };
+        }
+
+        this.sendResponse(response);
+    }
+
+    protected scopesRequest(
+        response: DebugProtocol.ScopesResponse,
+        args: DebugProtocol.ScopesArguments
+    ): void {
+        const scopes: Scope[] = [{
+            name: "Locals (use 'print' to evaluate)",
+            variablesReference: 0,
+            expensive: false
+        }];
+        response.body = { scopes: scopes };
+        this.sendResponse(response);
+    }
+
+    protected async variablesRequest(
+        response: DebugProtocol.VariablesResponse,
+        args: DebugProtocol.VariablesArguments
+    ): Promise<void> {
+        response.body = { variables: [] };
+        this.sendResponse(response);
+    }
+
+    // Manages stepping, continuing and other debug control operations
+    protected async stepInRequest(
+        response: DebugProtocol.StepInResponse,
+        args: DebugProtocol.StepInArguments
+    ): Promise<void> {
+        if (!this.client) {
+            this.sendResponse(response);
+            return;
+        }
+        await this.client.sendCommand("s");
+        this.sendResponse(response);
+        this.sendEvent(new StoppedEvent('step', GnoDebugSession.THREAD_ID));
+    }
+
+    protected async stepInstructionRequest(
+        response: DebugProtocol.StepInResponse,
+        args: DebugProtocol.StepInArguments
+    ): Promise<void> {
+        if (!this.client) {
+            this.sendResponse(response);
+            return;
+        }
+        await this.client.sendCommand("si");
+        this.sendResponse(response);
+        this.sendEvent(new StoppedEvent('step', GnoDebugSession.THREAD_ID));
+    }
+
+    protected async continueRequest(
+        response: DebugProtocol.ContinueResponse,
+        args: DebugProtocol.ContinueArguments
+    ): Promise<void> {
+        if (!this.client) {
+            this.sendResponse(response);
+            return;
+        }
+        const output = await this.client.sendCommand("c");
+        if (output.toLowerCase().includes("terminated")) {
+            this.sendResponse(response);
+            this.sendEvent(new TerminatedEvent());
+        } else {
+            this.sendResponse(response);
+            this.sendEvent(new StoppedEvent('breakpoint', GnoDebugSession.THREAD_ID));
+        }
+    }
+
+    protected sourceRequest(
+        response: DebugProtocol.SourceResponse,
+        args: DebugProtocol.SourceArguments
+    ): void {
+        if (args.source && args.source.path) {
+            try {
+                const content = fs.readFileSync(args.source.path, 'utf8');
+                response.body = { content: content };
+            } catch (e) {
+                response.body = { content: "" };
+            }
+        } else {
+            response.body = { content: "" };
+        }
+        this.sendResponse(response);
+    }
+
+    protected async disconnectRequest(
+        response: DebugProtocol.DisconnectResponse,
+        args: DebugProtocol.DisconnectArguments
+    ): Promise<void> {
+        if (this.client) {
+            await this.client.sendCommand("q");
+            this.client.dispose();
+        }
+        this.sendResponse(response);
+        this.sendEvent(new TerminatedEvent());
+    }
+
+    public static run(): void {
+        const session = new GnoDebugSession();
+        session.start(process.stdin, process.stdout);
+    }
 }
-
-GnoDebugSession.run(GnoDebugSession);

--- a/extension/src/gnoDebugConfiguration.ts
+++ b/extension/src/gnoDebugConfiguration.ts
@@ -1,63 +1,18 @@
-import { config } from 'process';
 import * as vscode from 'vscode';
 
 export class GnoDebugConfigurationProvider implements vscode.DebugConfigurationProvider {
-	static activate(ctx: vscode.ExtensionContext) {
-		ctx.subscriptions.push(
-			vscode.debug.registerDebugConfigurationProvider('gno', new GnoDebugConfigurationProvider())
-		);
-	}
-
-	public async provideDebugConfigurations(_folder: vscode.WorkspaceFolder | undefined, _token?: vscode.CancellationToken): Promise<vscode.DebugConfiguration[]> {
-		return await this.pickConfiguration();
-	}
-
-	private async pickConfiguration(): Promise<vscode.DebugConfiguration[]> {
-		const debugConfigurations = [
-			{
-				label: 'Gno: Launch Program',
-				description: 'Run and debug a gno program',
-				config: {
-					name: 'Launch program',
-					type: 'gno',
-					request: 'launch',
-					program: '${workspaceFolder}/main.gno'
-				}
-			},
-			{
-				label: 'Gno: Attach to Process',
-				description: 'Attach to a running Gno process',
-				config: {
-					name: 'Attach to Process',
-					type: 'gno',
-					request: 'attach',
-					processId: '${command:pickProcess}'
-				}
-			}
-		];
-
-		const choice = await vscode.window.showQuickPick(debugConfigurations, {
-			placeHolder: 'Choose a Gno debug configuration'
-		});
-
-		if (!choice) {
-			return [];
+	resolveDebugConfiguration(
+		folder: vscode.WorkspaceFolder | undefined,
+		config: vscode.DebugConfiguration,
+		token?: vscode.CancellationToken
+	): vscode.ProviderResult<vscode.DebugConfiguration> {
+		// Config by default
+		if (!config.type && !config.request && !config.name) {
+			config.type = 'gno';
+			config.name = 'Launch Gno Debugger';
+			config.request = 'launch';
+			config.program = '${file}';
 		}
-		return [choice.config]
-	}
-
-	public async resolveDebugConfiguration(folder: vscode.WorkspaceFolder | undefined, debugConfiguration: vscode.DebugConfiguration, _token?: vscode.CancellationToken): Promise<vscode.DebugConfiguration | undefined> {
-		if (!debugConfiguration.program && vscode.window.activeTextEditor) {
-			debugConfiguration.program = vscode.window.activeTextEditor.document.fileName;
-		}
-
-		if (!debugConfiguration.program) {
-			await vscode.window.showErrorMessage(
-				'No program specified in the debug configuration. Please set the "program" attribute.'
-			);
-			return undefined
-		}
-
-		return debugConfiguration;
+		return config;
 	}
 }

--- a/extension/src/gnoDebugConfiguration.ts
+++ b/extension/src/gnoDebugConfiguration.ts
@@ -1,0 +1,63 @@
+import { config } from 'process';
+import * as vscode from 'vscode';
+
+export class GnoDebugConfigurationProvider implements vscode.DebugConfigurationProvider {
+	static activate(ctx: vscode.ExtensionContext) {
+		ctx.subscriptions.push(
+			vscode.debug.registerDebugConfigurationProvider('gno', new GnoDebugConfigurationProvider())
+		);
+	}
+
+	public async provideDebugConfigurations(_folder: vscode.WorkspaceFolder | undefined, _token?: vscode.CancellationToken): Promise<vscode.DebugConfiguration[]> {
+		return await this.pickConfiguration();
+	}
+
+	private async pickConfiguration(): Promise<vscode.DebugConfiguration[]> {
+		const debugConfigurations = [
+			{
+				label: 'Gno: Launch Program',
+				description: 'Run and debug a gno program',
+				config: {
+					name: 'Launch program',
+					type: 'gno',
+					request: 'launch',
+					program: '${workspaceFolder}/main.gno'
+				}
+			},
+			{
+				label: 'Gno: Attach to Process',
+				description: 'Attach to a running Gno process',
+				config: {
+					name: 'Attach to Process',
+					type: 'gno',
+					request: 'attach',
+					processId: '${command:pickProcess}'
+				}
+			}
+		];
+
+		const choice = await vscode.window.showQuickPick(debugConfigurations, {
+			placeHolder: 'Choose a Gno debug configuration'
+		});
+
+		if (!choice) {
+			return [];
+		}
+		return [choice.config]
+	}
+
+	public async resolveDebugConfiguration(folder: vscode.WorkspaceFolder | undefined, debugConfiguration: vscode.DebugConfiguration, _token?: vscode.CancellationToken): Promise<vscode.DebugConfiguration | undefined> {
+		if (!debugConfiguration.program && vscode.window.activeTextEditor) {
+			debugConfiguration.program = vscode.window.activeTextEditor.document.fileName;
+		}
+
+		if (!debugConfiguration.program) {
+			await vscode.window.showErrorMessage(
+				'No program specified in the debug configuration. Please set the "program" attribute.'
+			);
+			return undefined
+		}
+
+		return debugConfiguration;
+	}
+}

--- a/extension/src/gnoDebugFactory.ts
+++ b/extension/src/gnoDebugFactory.ts
@@ -1,21 +1,13 @@
 import * as vscode from 'vscode';
+import { GnoDebugSession } from './debugAdapter/gnoDebug';
 
-export class GnoDebugAdapterDescriptorFactory implements vscode.DebugAdapterDescriptorFactory {
-	constructor(private outputChannel: vscode.OutputChannel) {}
-	public createDebugAdapterDescriptor(session: vscode.DebugSession, executable: vscode.DebugAdapterExecutable | undefined): vscode.ProviderResult<vscode.DebugAdapterDescriptor> {
-		// if use extern DAP server
-		if (session.configuration.remote) {
-			const host = session.configuration.host || '127.0.0.1';
-			const port = session.configuration.port || 2345;
-			this.outputChannel.appendLine(`Connecting to Gno debug server at ${host}:${port}`);
-			return new vscode.DebugAdapterServer(port, host);
-		}
-
-		// if use intern adapter
-		const command = 'node';
-		const args = [vscode.extensions.getExtension('gno.debug')!.extensionPath + '/out/debugAdapter.js'];
-		this.outputChannel.appendLine(`Starting Gno debug adapter: ${command} ${args.join(' ')}`);
-
-		return new vscode.DebugAdapterExecutable(command, args);
-	}
+export class GnoDebugAdapterDescriptorFactory implements vscode.DebugAdapterDescriptorFactory {    
+    createDebugAdapterDescriptor(
+        session: vscode.DebugSession,
+        executable: vscode.DebugAdapterExecutable | undefined
+    ): vscode.ProviderResult<vscode.DebugAdapterDescriptor> {
+        // Create a new session each time
+        const debugSession = new GnoDebugSession();
+        return new vscode.DebugAdapterInlineImplementation(debugSession);
+    }
 }

--- a/extension/src/gnoDebugFactory.ts
+++ b/extension/src/gnoDebugFactory.ts
@@ -1,0 +1,21 @@
+import * as vscode from 'vscode';
+
+export class GnoDebugAdapterDescriptorFactory implements vscode.DebugAdapterDescriptorFactory {
+	constructor(private outputChannel: vscode.OutputChannel) {}
+	public createDebugAdapterDescriptor(session: vscode.DebugSession, executable: vscode.DebugAdapterExecutable | undefined): vscode.ProviderResult<vscode.DebugAdapterDescriptor> {
+		// if use extern DAP server
+		if (session.configuration.remote) {
+			const host = session.configuration.host || '127.0.0.1';
+			const port = session.configuration.port || 2345;
+			this.outputChannel.appendLine(`Connecting to Gno debug server at ${host}:${port}`);
+			return new vscode.DebugAdapterServer(port, host);
+		}
+
+		// if use intern adapter
+		const command = 'node';
+		const args = [vscode.extensions.getExtension('gno.debug')!.extensionPath + '/out/debugAdapter.js'];
+		this.outputChannel.appendLine(`Starting Gno debug adapter: ${command} ${args.join(' ')}`);
+
+		return new vscode.DebugAdapterExecutable(command, args);
+	}
+}

--- a/extension/src/gnoMain.ts
+++ b/extension/src/gnoMain.ts
@@ -54,6 +54,8 @@ import { GoExtensionContext } from './context';
 import * as commands from './commands';
 import { GoTaskProvider } from './gnoTaskProvider';
 import { addPackage } from './gnoAddPkg';
+import { GnoDebugConfigurationProvider } from './gnoDebugConfiguration';
+import { GnoDebugAdapterDescriptorFactory } from './gnoDebugFactory';
 
 const goCtx: GoExtensionContext = {};
 
@@ -79,6 +81,15 @@ export async function activate(ctx: vscode.ExtensionContext): Promise<ExtensionA
 	setGlobalState(ctx.globalState);
 	setWorkspaceState(ctx.workspaceState);
 	setEnvironmentVariableCollection(ctx.environmentVariableCollection);
+
+	//debugger
+	ctx.subscriptions.push(
+		vscode.debug.registerDebugConfigurationProvider('gno', new GnoDebugConfigurationProvider())
+	);
+
+	ctx.subscriptions.push(
+		vscode.debug.registerDebugAdapterDescriptorFactory('gno', new GnoDebugAdapterDescriptorFactory())
+	)
 
 	const cfg = getGnoConfig();
 	WelcomePanel.activate(ctx, goCtx);
@@ -134,6 +145,7 @@ export async function activate(ctx: vscode.ExtensionContext): Promise<ExtensionA
 	registerCommand('gno.gnoroot', commands.getCurrentGoRoot);
 	registerCommand('gno.locate.tools', commands.getConfiguredGoTools);
 	registerCommand('gno.test.cursor', commands.testAtCursor('test'));
+	registerCommand('gno.debug.cursor', commands.testAtCursor('debug'));
 	registerCommand('gno.test.cursorOrPrevious', commands.testAtCursorOrPrevious('test'));
 	registerCommand('gno.test.file', commands.testCurrentFile());
 	registerCommand('gno.test.workspace', commands.testWorkspace);
@@ -152,7 +164,7 @@ export async function activate(ctx: vscode.ExtensionContext): Promise<ExtensionA
 
 	GoExplorerProvider.setup(ctx);
 
-	registerCommand('gno.debug.startSession', commands.startDebugSession);
+	//registerCommand('gno.debug.startSession', commands.startDebugSession);
 	registerCommand('gno.show.commands', commands.showCommands);
 	registerCommand('gno.lint.workspace', lintCode('workspace'));
 	registerCommand('gno.lint.file', lintCode('file'));
@@ -163,6 +175,10 @@ export async function activate(ctx: vscode.ExtensionContext): Promise<ExtensionA
 
 	// Go Environment switching commands
 	registerCommand('gno.environment.choose', chooseGoEnvironment);
+
+	// With other registerCommand calls
+	// Add with other command registrations
+	// Add to existing commands registration section
 
 	addOnDidChangeConfigListeners(ctx);
 	addOnChangeTextDocumentListeners(ctx);


### PR DESCRIPTION
This PR adds the Gno debugger. Currently, the Gno debugger does not integrate the DAP protocol. This version implements the debugger using the Bridge Pattern, which works as follows:

- Uses an intermediary layer (GnoDebugSession) that translates commands
- Communicates with the debugger via a child process
- Manually parses the debugger's output

This implementation is not fully optimized yet, so I am marking this PR as a draft until the DAP protocol is implemented to ensure an optimal debugger in the extension.