### PR TITLE
feat: add gnodev support

### DIFF
--- a/extension/.gitignore
+++ b/extension/.gitignore
@@ -8,3 +8,4 @@ node_modules/
 package-lock.json
 gnopls/gno_functions/.git
 gnopls/gno_functions/.git
+*.vsix

--- a/extension/package.json
+++ b/extension/package.json
@@ -270,6 +270,16 @@
         "command": "gno.maketx.addpkg",
         "title": "Gno Add Package To Chain",
         "description": "Add a package to the Gno blockchain"
+      },
+      {
+        "command": "gno.dev.server.start",
+        "title": "Gno: Start Development Server",
+        "description": "Start gnodev server and open in Simple Browser"
+      },
+      {
+        "command": "gno.dev.server.stop",
+        "title": "Gno: Stop Development Server",
+        "description": "Stop gnodev server"
       }
     ],
     "breakpoints": [
@@ -289,36 +299,36 @@
         "gno.makeTx": {
           "type": "object",
           "properties": {
-              "broadcast": {
-                  "type": "boolean",
-                  "default": true,
-                  "description": "If true, broadcasts transaction to chain"
-              },
-              "gasFee": {
-                  "type": "string",
-                  "default": "1000000ugnot",
-                  "description": "Gas fee for transaction"
-              },
-              "gasWanted": {
-                  "type": "string",
-                  "default": "2000000",
-                  "description": "Gas wanted for transaction"
-              }
+            "broadcast": {
+              "type": "boolean",
+              "default": true,
+              "description": "If true, broadcasts transaction to chain"
+            },
+            "gasFee": {
+              "type": "string",
+              "default": "1000000ugnot",
+              "description": "Gas fee for transaction"
+            },
+            "gasWanted": {
+              "type": "string",
+              "default": "2000000",
+              "description": "Gas wanted for transaction"
+            }
           },
           "additionalProperties": false,
           "default": {
-              "broadcast": true,
-              "gasFee": "1000000ugnot",
-              "gasWanted": "4000000"
+            "broadcast": true,
+            "gasFee": "1000000ugnot",
+            "gasWanted": "4000000"
           },
           "description": "Configuration for Gno blockchain transactions",
           "scope": "resource"
-      },
-      "gno.editorContextMenuCommands.addPackage": {
+        },
+        "gno.editorContextMenuCommands.addPackage": {
           "type": "boolean",
           "default": true,
           "description": "If true, adds command to add package to the Gno blockchain to the editor context menu"
-      },
+        },
         "gno.disableConcurrentTests": {
           "type": "boolean",
           "default": false,
@@ -464,6 +474,15 @@
           "default": true,
           "description": "Open the test output terminal when a test run is started.",
           "scope": "window"
+        },
+        "gno.gnodevFlags": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": [],
+          "description": "Flags to pass to gnodev command (e.g. [\"-v\", \"-paths <custom-path>\"])",
+          "scope": "resource"
         },
         "gno.useLanguageServer": {
           "type": "boolean",
@@ -1258,3 +1277,4 @@
     ]
   }
 }
+

--- a/extension/package.json
+++ b/extension/package.json
@@ -484,6 +484,12 @@
           "description": "Flags to pass to gnodev command (e.g. [\"-v\", \"-paths <custom-path>\"])",
           "scope": "resource"
         },
+        "gno.gnodevOpenBrowser": {
+          "type": "boolean",
+          "default": true,
+          "description": "Open Simple Browser automatically when gnodev server starts",
+          "scope": "resource"
+        },
         "gno.useLanguageServer": {
           "type": "boolean",
           "default": true,

--- a/extension/package.json
+++ b/extension/package.json
@@ -475,7 +475,7 @@
           "description": "Open the test output terminal when a test run is started.",
           "scope": "window"
         },
-        "gno.gnodevFlags": {
+        "gno.gnodev.flags": {
           "type": "array",
           "items": {
             "type": "string"
@@ -484,7 +484,7 @@
           "description": "Flags to pass to gnodev command (e.g. [\"-v\", \"-paths <custom-path>\"])",
           "scope": "resource"
         },
-        "gno.gnodevOpenBrowser": {
+        "gno.gnodev.openBrowser": {
           "type": "string",
           "enum": [
             "none",
@@ -1295,4 +1295,3 @@
     ]
   }
 }
-

--- a/extension/package.json
+++ b/extension/package.json
@@ -274,12 +274,12 @@
       {
         "command": "gno.dev.server.start",
         "title": "Gno: Start Development Server",
-        "description": "Start gnodev server and open in Simple Browser"
+        "description": "Start gnodev server and open its webview"
       },
       {
         "command": "gno.dev.server.stop",
         "title": "Gno: Stop Development Server",
-        "description": "Stop gnodev server"
+        "description": "Stop gnodev server and close its webview"
       }
     ],
     "breakpoints": [

--- a/extension/package.json
+++ b/extension/package.json
@@ -485,9 +485,21 @@
           "scope": "resource"
         },
         "gno.gnodevOpenBrowser": {
-          "type": "boolean",
-          "default": true,
-          "description": "Open Simple Browser automatically when gnodev server starts",
+          "type": "string",
+          "enum": [
+            "none",
+            "current",
+            "beside",
+            "external"
+          ],
+          "enumDescriptions": [
+            "Do not open gnodev interface",
+            "Open gnodev interface in the current webview",
+            "Open gnodev interface in a webview beside the current one",
+            "Open gnodev interface in external browser"
+          ],
+          "default": "beside",
+          "description": "Controls how the gnodev interface opens when the server starts",
           "scope": "resource"
         },
         "gno.useLanguageServer": {

--- a/extension/src/commands/index.ts
+++ b/extension/src/commands/index.ts
@@ -17,7 +17,7 @@ export { installTools } from './installTools';
 export { runBuilds } from './runBuilds';
 export { showCommands } from './showCommands';
 export { startDebugSession } from './startDebugSession';
-export { startGnoDevServer, stopGnoDevServerCommand } from './startGnoDevServer';
+export { startGnoDevServer, stopGnoDevServer } from './startGnoDevServer';
 export { startLanguageServer } from './startLanguageServer';
 export { startGoplsMaintainerInterface } from './startLanguageServer';
 

--- a/extension/src/commands/index.ts
+++ b/extension/src/commands/index.ts
@@ -17,6 +17,7 @@ export { installTools } from './installTools';
 export { runBuilds } from './runBuilds';
 export { showCommands } from './showCommands';
 export { startDebugSession } from './startDebugSession';
+export { startGnoDevServer, stopGnoDevServerCommand } from './startGnoDevServer';
 export { startLanguageServer } from './startLanguageServer';
 export { startGoplsMaintainerInterface } from './startLanguageServer';
 

--- a/extension/src/commands/startGnoDevServer.ts
+++ b/extension/src/commands/startGnoDevServer.ts
@@ -1,6 +1,7 @@
 import * as vscode from 'vscode';
 import { CommandFactory } from './index';
-import { GnodevProcess, GnodevAddress } from '../gnodev/gnodevProcess';
+import { GnodevProcess } from '../gnodev/gnodevProcess';
+import { GnodevAddress } from '../gnodev/address';
 import { GnodevWebView } from '../gnodev/gnodevWebView';
 
 interface GnoDevServer {

--- a/extension/src/commands/startGnoDevServer.ts
+++ b/extension/src/commands/startGnoDevServer.ts
@@ -26,7 +26,7 @@ export const startGnoDevServer: CommandFactory = (ctx) => {
 			currentGnoDevServer.process.onProcessReady((addr: GnodevAddress) => {
 				// Get the openBrowser setting to determine how the gnodev interface should be opened.
 				const config = vscode.workspace.getConfiguration('gno');
-				const openBrowser: string = config.get('gnodevOpenBrowser', 'beside');
+				const openBrowser: string = config.get('gnodev.openBrowser', 'beside');
 
 				// Handle the different openBrowser options.
 				if (openBrowser !== 'none' && currentGnoDevServer) {

--- a/extension/src/commands/startGnoDevServer.ts
+++ b/extension/src/commands/startGnoDevServer.ts
@@ -1,0 +1,118 @@
+import * as vscode from 'vscode';
+import { spawn, ChildProcess } from 'child_process';
+import { CommandFactory } from './index';
+import { outputChannel } from '../gnoStatus';
+import { getBinPath } from '../util';
+
+interface GnoDevProcess {
+	process: ChildProcess;
+	dispose: () => void;
+}
+
+let currentGnoDevProcess: GnoDevProcess | undefined;
+
+export const startGnoDevServer: CommandFactory = () => {
+	return async () => {
+		try {
+			// Stop any existing gnodev process
+			stopGnoDevServer();
+
+			// Get the current workspace folder
+			const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
+			if (!workspaceFolder) {
+				vscode.window.showErrorMessage(
+					'No workspace folder found. Please open a workspace to start the development server.'
+				);
+				return;
+			}
+
+			// Get the gno binary path
+			const gnodevBinPath = getBinPath('gnodev');
+
+			// Get gnodev flags from configuration
+			const config = vscode.workspace.getConfiguration('gno');
+			const gnodevFlags: string[] = config.get('gnodevFlags', []);
+
+			outputChannel.show();
+			outputChannel.appendLine('Starting Gno development server...');
+
+			// Build command arguments: ['dev', ...flags]
+			const args = ['dev', ...gnodevFlags];
+
+			// Start gnodev process
+			const gnodevProcess = spawn(gnodevBinPath, args, {
+				cwd: workspaceFolder.uri.fsPath,
+				stdio: ['pipe', 'pipe', 'pipe']
+			});
+
+			// Handle process output
+			gnodevProcess.stdout?.on('data', (data: Buffer) => {
+				const output = data.toString();
+				outputChannel.appendLine(output);
+
+				// Check if server is ready (look for the READY message)
+				if (output.includes('gnoweb started')) {
+					// Open Simple Browser after a short delay to ensure server is fully ready
+					setTimeout(() => {
+						vscode.commands.executeCommand('simpleBrowser.show', 'http://127.0.0.1:8888');
+					}, 50);
+				}
+			});
+
+			gnodevProcess.stderr?.on('data', (data: Buffer) => {
+				outputChannel.appendLine(`Error: ${data.toString()}`);
+			});
+
+			gnodevProcess.on('error', (error) => {
+				outputChannel.appendLine(`Failed to start gnodev: ${error.message}`);
+				vscode.window.showErrorMessage(`Failed to start gnodev: ${error.message}`);
+				currentGnoDevProcess = undefined;
+			});
+
+			gnodevProcess.on('exit', (code, signal) => {
+				outputChannel.appendLine(`Gnodev process exited with code ${code}, signal ${signal}`);
+				currentGnoDevProcess = undefined;
+			});
+
+			// Create disposal function
+			const dispose = () => {
+				if (gnodevProcess && !gnodevProcess.killed) {
+					outputChannel.appendLine('Stopping Gno development server...');
+					gnodevProcess.kill();
+				}
+			};
+
+			currentGnoDevProcess = {
+				process: gnodevProcess,
+				dispose
+			};
+
+			vscode.window.showInformationMessage('Gno development server started! Opening in Simple Browser...');
+		} catch (error) {
+			const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+			outputChannel.appendLine(`Error starting gnodev: ${errorMessage}`);
+			vscode.window.showErrorMessage(`Failed to start gnodev: ${errorMessage}`);
+		}
+	};
+};
+
+// Export function to stop the server (can be used by other commands if needed)
+function stopGnoDevServer(): boolean {
+	if (currentGnoDevProcess) {
+		currentGnoDevProcess.dispose();
+		currentGnoDevProcess = undefined;
+		return true;
+	}
+	return false;
+}
+
+export const stopGnoDevServerCommand: CommandFactory = () => {
+	return async () => {
+		if (stopGnoDevServer()) {
+			outputChannel.appendLine('Gno development server stopped.');
+			vscode.window.showInformationMessage('Gno development server stopped.');
+		} else {
+			vscode.window.showInformationMessage('No Gno development server is currently running.');
+		}
+	};
+};

--- a/extension/src/gnoMain.ts
+++ b/extension/src/gnoMain.ts
@@ -145,8 +145,8 @@ export async function activate(ctx: vscode.ExtensionContext): Promise<ExtensionA
 	registerCommand('gno.add.package.workspace', addImportToWorkspace);
 	registerCommand('gno.tools.install', commands.installTools);
 	registerCommand('gno.maketx.addpkg', addPackage());
-	registerCommand('gno.dev.server', commands.startGnoDevServer);
-	registerCommand('gno.dev.server.stop', commands.stopGnoDevServerCommand);
+	registerCommand('gno.dev.server.start', commands.startGnoDevServer);
+	registerCommand('gno.dev.server.stop', commands.stopGnoDevServer);
 
 	if (isVscodeTestingAPIAvailable && cfg.get<boolean>('testExplorer.enable')) {
 		GoTestExplorer.setup(ctx, goCtx);
@@ -202,7 +202,7 @@ export function deactivate() {
 		cancelRunningTests(),
 		killRunningPprof(),
 		Promise.resolve(cleanupTempDir()),
-		Promise.resolve(disposeGoStatusBar()),
+		Promise.resolve(disposeGoStatusBar())
 	]);
 }
 

--- a/extension/src/gnoMain.ts
+++ b/extension/src/gnoMain.ts
@@ -145,6 +145,8 @@ export async function activate(ctx: vscode.ExtensionContext): Promise<ExtensionA
 	registerCommand('gno.add.package.workspace', addImportToWorkspace);
 	registerCommand('gno.tools.install', commands.installTools);
 	registerCommand('gno.maketx.addpkg', addPackage());
+	registerCommand('gno.dev.server', commands.startGnoDevServer);
+	registerCommand('gno.dev.server.stop', commands.stopGnoDevServerCommand);
 
 	if (isVscodeTestingAPIAvailable && cfg.get<boolean>('testExplorer.enable')) {
 		GoTestExplorer.setup(ctx, goCtx);

--- a/extension/src/gnoMain.ts
+++ b/extension/src/gnoMain.ts
@@ -8,7 +8,7 @@
 
 'use strict';
 
-import { extensionInfo, getGnoConfig } from './config';
+import { getGnoConfig } from './config';
 import { notifyIfGeneratedFile, removeTestStatus } from './gnoCheck';
 import { setGOROOTEnvVar, toolExecutionEnvironment } from './gnoEnv';
 import {
@@ -30,7 +30,8 @@ import { GO_MODE } from './gnoMode';
 import * as goGenerateTests from './gnoGenerateTests';
 import { GO111MODULE, goModInit } from './gnoModules';
 import { GoRunTestCodeLensProvider } from './gnoRunTestCodelens';
-import { disposeGoStatusBar, expandGoStatusBar, outputChannel, updateGoStatusBar } from './gnoStatus';
+import { disposeGoStatusBar, expandGoStatusBar, updateGoStatusBar } from './gnoStatus';
+import { disposeGnoDevServer } from './commands/startGnoDevServer';
 import {
 	getFromGlobalState,
 	resetGlobalState,
@@ -202,7 +203,8 @@ export function deactivate() {
 		cancelRunningTests(),
 		killRunningPprof(),
 		Promise.resolve(cleanupTempDir()),
-		Promise.resolve(disposeGoStatusBar())
+		Promise.resolve(disposeGoStatusBar()),
+		Promise.resolve(disposeGnoDevServer())
 	]);
 }
 

--- a/extension/src/gnodev/address.ts
+++ b/extension/src/gnodev/address.ts
@@ -1,0 +1,23 @@
+import * as vscode from 'vscode';
+
+export class GnodevAddress {
+	public host: string;
+	public port: number;
+
+	constructor(host: string, port: number) {
+		this.host = host;
+		this.port = port;
+	}
+
+	public toString(): string {
+		return `http://${this.host}:${this.port}`;
+	}
+
+	public toUri(): vscode.Uri {
+		return vscode.Uri.parse(this.toString());
+	}
+
+	public equals(other: GnodevAddress): boolean {
+		return this.host === other.host && this.port === other.port;
+	}
+}

--- a/extension/src/gnodev/gnodevProcess.ts
+++ b/extension/src/gnodev/gnodevProcess.ts
@@ -3,8 +3,6 @@ import { spawn, ChildProcess } from 'child_process';
 import { outputChannel } from '../gnoStatus';
 import { getBinPath } from '../util';
 
-export const restartDelay = 3000; // 3 seconds
-
 export class GnodevAddress {
 	public host: string;
 	public port: number;
@@ -29,7 +27,6 @@ export class GnodevAddress {
 
 export class GnodevProcess extends vscode.Disposable {
 	private _process: ChildProcess | undefined;
-	private _onDidDispose: (() => void) | undefined;
 	private _onProcessReady = new vscode.EventEmitter<GnodevAddress>();
 	private _onProcessExit = new vscode.EventEmitter<Error | undefined>();
 
@@ -48,16 +45,10 @@ export class GnodevProcess extends vscode.Disposable {
 		return this._process?.killed === false;
 	}
 
-	public onDidDispose(callback: () => void): void {
-		this._onDidDispose = callback;
-	}
-
 	public async start(): Promise<void> {
-		// If the process is already running, stop it first then wait 3 secs
-		// to ensure the ports are freed up before starting a new one.
+		// If the process is already running, stop it first.
 		if (this.isRunning) {
 			this.stop();
-			await new Promise((resolve) => setTimeout(resolve, restartDelay));
 		}
 
 		outputChannel.info('Starting gnodev process...');
@@ -139,8 +130,6 @@ export class GnodevProcess extends vscode.Disposable {
 
 	public dispose(): void {
 		this.stop();
-		this._onDidDispose?.();
-		this._onDidDispose = undefined;
 		this._onProcessReady.dispose();
 		this._onProcessExit.dispose();
 	}

--- a/extension/src/gnodev/gnodevProcess.ts
+++ b/extension/src/gnodev/gnodevProcess.ts
@@ -1,0 +1,147 @@
+import * as vscode from 'vscode';
+import { spawn, ChildProcess } from 'child_process';
+import { outputChannel } from '../gnoStatus';
+import { getBinPath } from '../util';
+
+export const restartDelay = 3000; // 3 seconds
+
+export class GnodevAddress {
+	public host: string;
+	public port: number;
+
+	constructor(host: string, port: number) {
+		this.host = host;
+		this.port = port;
+	}
+
+	public toString(): string {
+		return `http://${this.host}:${this.port}`;
+	}
+
+	public toUri(): vscode.Uri {
+		return vscode.Uri.parse(this.toString());
+	}
+
+	public compareTo(other: GnodevAddress): boolean {
+		return this.host === other.host && this.port === other.port;
+	}
+}
+
+export class GnodevProcess extends vscode.Disposable {
+	private _process: ChildProcess | undefined;
+	private _onDidDispose: (() => void) | undefined;
+	private _onProcessReady = new vscode.EventEmitter<GnodevAddress>();
+	private _onProcessExit = new vscode.EventEmitter<Error | undefined>();
+
+	public readonly onProcessReady = this._onProcessReady.event;
+	public readonly onProcessExit = this._onProcessExit.event;
+
+	constructor() {
+		super(() => this.dispose());
+	}
+
+	public get process(): ChildProcess | undefined {
+		return this._process;
+	}
+
+	public get isRunning(): boolean {
+		return this._process?.killed === false;
+	}
+
+	public onDidDispose(callback: () => void): void {
+		this._onDidDispose = callback;
+	}
+
+	public async start(): Promise<void> {
+		// If the process is already running, stop it first then wait 3 secs
+		// to ensure the ports are freed up before starting a new one.
+		if (this.isRunning) {
+			this.stop();
+			await new Promise((resolve) => setTimeout(resolve, restartDelay));
+		}
+
+		outputChannel.info('Starting gnodev process...');
+
+		try {
+			// Get the gnodev flags from the configuration.
+			const config = vscode.workspace.getConfiguration('gno');
+			const gnodevFlags: string[] = config.get('gnodevFlags', []);
+
+			// Get the path to the gnodev binary.
+			const gnodevBinPath = getBinPath('gnodev');
+
+			// Get the workspace folder to run the gnodev process in.
+			const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
+			if (!workspaceFolder) {
+				throw new Error('No workspace folder found, please open one.');
+			}
+
+			// Spawn the gnodev process with the specified flags and in the workspace folder.
+			this._process = spawn(gnodevBinPath, gnodevFlags, {
+				cwd: workspaceFolder.uri.fsPath,
+				stdio: ['pipe', 'pipe', 'pipe']
+			});
+
+			// Listen for data on process stdout.
+			this._process.stdout?.on('data', (data: Buffer) => {
+				const output = data.toString();
+
+				// Forward process stdout to the output channel.
+				outputChannel.appendLine(output);
+
+				// Check if the output contains the expected message indicating the process has started.
+				const regex = /gnoweb started lisn=http:\/\/([^:]+):(\d+)/;
+				const match = output.match(regex);
+
+				if (match) {
+					// Extract the host and port from the output.
+					const host = match[1];
+					const port = parseInt(match[2], 10);
+
+					// Emit the ready event with the address of the gnodev process.
+					this._onProcessReady.fire(new GnodevAddress(host, port));
+				}
+			});
+
+			// Forward process stderr to the output channel.
+			this._process.stderr?.on('data', (data: Buffer) => {
+				outputChannel.error(data.toString());
+			});
+
+			// Fire an error event if the process fails to start.
+			this._process.on('error', (error) => {
+				this._onProcessExit.fire(new Error(`Failed to start gnodev: ${error.message}`));
+			});
+
+			// Handle process exit event.
+			this._process.on('exit', (code, signal) => {
+				const exitStatus = `Gnodev process exited with code ${code}, signal ${signal}`;
+
+				outputChannel.info(exitStatus);
+
+				// Fire the exit event with an error if any.
+				this._onProcessExit.fire(code !== 0 ? new Error(exitStatus) : undefined);
+			});
+		} catch (error) {
+			const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+			throw new Error(`Error starting gnodev: ${errorMessage}`);
+		}
+	}
+
+	public stop(): void {
+		if (this.isRunning) {
+			outputChannel.info('Stopping gnodev process...');
+			this._process!.kill();
+		}
+
+		this._process = undefined;
+	}
+
+	public dispose(): void {
+		this.stop();
+		this._onDidDispose?.();
+		this._onDidDispose = undefined;
+		this._onProcessReady.dispose();
+		this._onProcessExit.dispose();
+	}
+}

--- a/extension/src/gnodev/gnodevProcess.ts
+++ b/extension/src/gnodev/gnodevProcess.ts
@@ -79,7 +79,7 @@ export class GnodevProcess extends vscode.Disposable {
 						}
 					}
 				} catch (error) {
-					outputChannel.error(defaultGroup, `Failed to parse gnodev log line: ${line}`);
+					outputChannel.error(defaultGroup, `failed to parse gnodev log line: ${line}`);
 				}
 			});
 

--- a/extension/src/gnodev/gnodevProcess.ts
+++ b/extension/src/gnodev/gnodevProcess.ts
@@ -36,7 +36,7 @@ export class GnodevProcess extends vscode.Disposable {
 		try {
 			// Get the gnodev flags from the configuration.
 			const config = vscode.workspace.getConfiguration('gno');
-			const gnodevFlags: string[] = config.get('gnodevFlags', []);
+			const gnodevFlags: string[] = config.get('gnodev.flags', []);
 
 			// Get the path to the gnodev binary.
 			const gnodevBinPath = getBinPath('gnodev');

--- a/extension/src/gnodev/gnodevWebView.ts
+++ b/extension/src/gnodev/gnodevWebView.ts
@@ -48,8 +48,8 @@ export class GnodevWebView extends vscode.Disposable {
 		}
 
 		// Using `vscode.env.asExternalUri` to ensure the URL is accessible when running in Codespaces.
-		const gnodevURL = await vscode.env.asExternalUri(this._currAddr.toUri());
-		outputChannel.info(defaultGroup, 'opening gnodev webview', { url: gnodevURL });
+		const externalUri = (await vscode.env.asExternalUri(this._currAddr.toUri())).toString();
+		outputChannel.info(defaultGroup, 'opening gnodev webview', { uri: externalUri });
 
 		// The webview HTML content is just an iframe pointing to the gnodev server URL.
 		this._panel.webview.html = `
@@ -75,7 +75,7 @@ export class GnodevWebView extends vscode.Disposable {
 			</head>
 			<body>
 				<iframe
-					src="${gnodevURL}"
+					src="${externalUri}"
 					sandbox="allow-scripts allow-forms allow-same-origin allow-downloads">
 				</iframe>
 			</body>

--- a/extension/src/gnodev/gnodevWebView.ts
+++ b/extension/src/gnodev/gnodevWebView.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode';
 import { joinPath } from '../util';
-import { GnodevAddress } from './gnodevProcess';
-import { outputChannel } from '../gnoStatus';
+import { defaultGroup, outputChannel } from './logs';
+import { GnodevAddress } from './address';
 
 export class GnodevWebView extends vscode.Disposable {
 	private _context: vscode.ExtensionContext;
@@ -24,7 +24,7 @@ export class GnodevWebView extends vscode.Disposable {
 
 	public async create(addr: GnodevAddress, viewColumn: vscode.ViewColumn): Promise<void> {
 		// If the webview panel for this gnodev address already exists, just reveal it.
-		if (this._panel && this._currAddr?.compareTo(addr)) {
+		if (this._panel && this._currAddr?.equals(addr)) {
 			this._panel.reveal();
 			return;
 		}
@@ -49,7 +49,7 @@ export class GnodevWebView extends vscode.Disposable {
 
 		// Using `vscode.env.asExternalUri` to ensure the URL is accessible when running in Codespaces.
 		const gnodevURL = await vscode.env.asExternalUri(this._currAddr.toUri());
-		outputChannel.info(`Opening gnodev webview at: ${gnodevURL}`);
+		outputChannel.info(defaultGroup, 'opening gnodev webview', { url: gnodevURL });
 
 		// The webview HTML content is just an iframe pointing to the gnodev server URL.
 		this._panel.webview.html = `
@@ -93,7 +93,7 @@ export class GnodevWebView extends vscode.Disposable {
 			const prevPanel = this._panel;
 			this._panel = undefined;
 
-			outputChannel.info('Closing gnodev webview');
+			outputChannel.info(defaultGroup, 'closing gnodev webview');
 			prevPanel.dispose();
 		}
 

--- a/extension/src/gnodev/gnodevWebView.ts
+++ b/extension/src/gnodev/gnodevWebView.ts
@@ -22,7 +22,7 @@ export class GnodevWebView extends vscode.Disposable {
 		this._onDidDispose = callback;
 	}
 
-	public async create(addr: GnodevAddress): Promise<void> {
+	public async create(addr: GnodevAddress, viewColumn: vscode.ViewColumn): Promise<void> {
 		// If the webview panel for this gnodev address already exists, just reveal it.
 		if (this._panel && this._currAddr?.compareTo(addr)) {
 			this._panel.reveal();
@@ -30,8 +30,8 @@ export class GnodevWebView extends vscode.Disposable {
 		}
 		this._currAddr = addr;
 
-		// Init the webview panel on a new column beside the current one.
-		this._panel = vscode.window.createWebviewPanel('gnodev', 'Gnodev', vscode.ViewColumn.Beside, {
+		// Init the webview panel on the specified column.
+		this._panel = vscode.window.createWebviewPanel('gnodev', 'Gnodev', viewColumn, {
 			enableScripts: true,
 			retainContextWhenHidden: true
 		});
@@ -90,12 +90,18 @@ export class GnodevWebView extends vscode.Disposable {
 
 	public dispose(): void {
 		if (this._panel) {
-			outputChannel.info('Closing gnodev webview');
-			this._panel.dispose();
+			const prevPanel = this._panel;
 			this._panel = undefined;
+
+			outputChannel.info('Closing gnodev webview');
+			prevPanel.dispose();
 		}
 
-		this._onDidDispose?.();
-		this._onDidDispose = undefined;
+		if (this._onDidDispose) {
+			const prevOnDidDispose = this._onDidDispose;
+			this._onDidDispose = undefined;
+
+			prevOnDidDispose();
+		}
 	}
 }

--- a/extension/src/gnodev/gnodevWebView.ts
+++ b/extension/src/gnodev/gnodevWebView.ts
@@ -1,0 +1,101 @@
+import * as vscode from 'vscode';
+import { joinPath } from '../util';
+import { GnodevAddress } from './gnodevProcess';
+import { outputChannel } from '../gnoStatus';
+
+export class GnodevWebView extends vscode.Disposable {
+	private _context: vscode.ExtensionContext;
+	private _panel: vscode.WebviewPanel | undefined;
+	private _currAddr: GnodevAddress | undefined;
+	private _onDidDispose: (() => void) | undefined;
+
+	constructor(context: vscode.ExtensionContext) {
+		super(() => this.dispose());
+		this._context = context;
+	}
+
+	public get panel(): vscode.WebviewPanel | undefined {
+		return this._panel;
+	}
+
+	public onDidDispose(callback: () => void): void {
+		this._onDidDispose = callback;
+	}
+
+	public async create(addr: GnodevAddress): Promise<void> {
+		// If the webview panel for this gnodev address already exists, just reveal it.
+		if (this._panel && this._currAddr?.compareTo(addr)) {
+			this._panel.reveal();
+			return;
+		}
+		this._currAddr = addr;
+
+		// Init the webview panel on a new column beside the current one.
+		this._panel = vscode.window.createWebviewPanel('gnodev', 'Gnodev', vscode.ViewColumn.Beside, {
+			enableScripts: true,
+			retainContextWhenHidden: true
+		});
+
+		// Set the webview icons.
+		this._panel.iconPath = {
+			light: joinPath(this._context.extensionUri, 'media', 'gno-logo-light.png'),
+			dark: joinPath(this._context.extensionUri, 'media', 'gno-logo-dark.png')
+		};
+
+		// Workaround for the gnodev server not being accessible via localhost on macOS if IPv6 is enabled.
+		if (this._currAddr.host === 'localhost' && process.platform === 'darwin') {
+			this._currAddr.host = '127.0.0.1';
+		}
+
+		// Using `vscode.env.asExternalUri` to ensure the URL is accessible when running in Codespaces.
+		const gnodevURL = await vscode.env.asExternalUri(this._currAddr.toUri());
+		outputChannel.info(`Opening gnodev webview at: ${gnodevURL}`);
+
+		// The webview HTML content is just an iframe pointing to the gnodev server URL.
+		this._panel.webview.html = `
+			<!DOCTYPE html>
+			<html>
+			<head>
+				<meta charset="UTF-8">
+				<meta name="viewport" content="width=device-width, initial-scale=1.0">
+				<style>
+					body, html {
+						margin: 0;
+						padding: 0;
+						width: 100%;
+						height: 100%;
+						overflow: hidden;
+					}
+					iframe {
+						width: 100%;
+						height: 100vh;
+						border: none;
+					}
+				</style>
+			</head>
+			<body>
+				<iframe
+					src="${gnodevURL}"
+					sandbox="allow-scripts allow-forms allow-same-origin allow-downloads">
+				</iframe>
+			</body>
+			</html>
+		`;
+
+		// If the webview is closed, call the dispose callback.
+		this._panel.onDidDispose(() => {
+			this.dispose();
+		});
+	}
+
+	public dispose(): void {
+		if (this._panel) {
+			outputChannel.info('Closing gnodev webview');
+			this._panel.dispose();
+			this._panel = undefined;
+		}
+
+		this._onDidDispose?.();
+		this._onDidDispose = undefined;
+	}
+}

--- a/extension/src/gnodev/logs.ts
+++ b/extension/src/gnodev/logs.ts
@@ -1,0 +1,94 @@
+import * as vscode from 'vscode';
+
+type JSONValue = string | number | boolean | null | JSONValue[] | JSONKeyValue;
+
+type JSONKeyValue = {
+	[key: string]: JSONValue;
+};
+
+enum Level {
+	Debug = 'debug',
+	Info = 'info',
+	Warn = 'warn',
+	Error = 'error'
+}
+
+interface GnodevLog {
+	level: Level;
+	group: string | undefined;
+	msg: string | undefined;
+	args: JSONKeyValue | undefined;
+}
+
+// Parse a JSON line from gnodev logs and return a structured GnodevLog object.
+export const parseGnodevLog = (line: string): GnodevLog => {
+	// Destructure to extract known fields and the rest
+	const { level, ts, msg, ...rest } = JSON.parse(line); // eslint-disable-line
+
+	// Identify the 'group' and 'args' by extracting the first key-value pair in 'rest'
+	const group = Object.keys(rest)[0];
+	const args = rest[group];
+
+	// Return the formatted Log object
+	return {
+		level,
+		group,
+		msg,
+		args
+	};
+};
+
+export class GnodevOutputChannel {
+	public readonly outputChannel: vscode.LogOutputChannel;
+
+	constructor() {
+		this.outputChannel = vscode.window.createOutputChannel('Gnodev', {
+			log: true
+		});
+	}
+
+	public log(log: GnodevLog): void {
+		switch (log.level) {
+			case Level.Debug:
+				this.debug(log.group, log.msg, log.args || {});
+				break;
+			case Level.Info:
+				this.info(log.group, log.msg, log.args || {});
+				break;
+			case Level.Warn:
+				this.warn(log.group, log.msg, log.args || {});
+				break;
+			case Level.Error:
+				this.error(log.group, log.msg, log.args || {});
+				break;
+			default:
+				throw new Error(`Unknown log level: ${log.level}`);
+		}
+	}
+
+	private formatMessage(group: string | undefined, message: string | undefined): string {
+		let formattedMessage = group ? `[${group}] ` : '';
+		formattedMessage += message ? message : '';
+		return formattedMessage;
+	}
+
+	public debug(group: string | undefined, message: string | undefined, ...args: any[]): void {
+		this.outputChannel.debug(this.formatMessage(group, message), ...args);
+	}
+
+	public info(group: string | undefined, message: string | undefined, ...args: any[]): void {
+		this.outputChannel.info(this.formatMessage(group, message), ...args);
+	}
+
+	public warn(group: string | undefined, message: string | undefined, ...args: any[]): void {
+		this.outputChannel.warn(this.formatMessage(group, message), ...args);
+	}
+
+	public error(group: string | undefined, message: string | undefined, ...args: any[]): void {
+		this.outputChannel.error(this.formatMessage(group, message), ...args);
+	}
+}
+
+export const defaultGroup = 'VSCode';
+
+export const outputChannel = new GnodevOutputChannel();

--- a/extension/src/util.ts
+++ b/extension/src/util.ts
@@ -809,6 +809,18 @@ export function getWorkspaceFolderPath(fileUri?: vscode.Uri): string | undefined
 	return undefined;
 }
 
+export function joinPath(uri: vscode.Uri, ...pathFragment: string[]): vscode.Uri {
+	// Reimplementation of
+	// https://github.com/microsoft/vscode/blob/b251bd952b84a3bdf68dad0141c37137dac55d64/src/vs/base/common/uri.ts#L346-L357
+	// with Node.JS path. This is a temporary workaround for https://github.com/eclipse-theia/theia/issues/8752.
+	if (!uri.path) {
+		throw new Error('[UriError]: cannot call joinPaths on URI without path');
+	}
+	return uri.with({
+		path: vscode.Uri.file(path.join(uri.fsPath, ...pathFragment)).path
+	});
+}
+
 export function rmdirRecursive(dir: string) {
 	if (fs.existsSync(dir)) {
 		fs.readdirSync(dir).forEach((file) => {

--- a/extension/src/welcome.ts
+++ b/extension/src/welcome.ts
@@ -8,13 +8,13 @@
 // https://github.com/microsoft/vscode-extension-samples/tree/master/webview-sample
 
 import vscode = require('vscode');
-import path = require('path');
 import semver = require('semver');
 import { extensionId } from './const';
 import { GoExtensionContext } from './context';
 import { extensionInfo, getGnoConfig } from './config';
 import { getFromGlobalState, updateGlobalState } from './stateUtils';
 import { createRegisterCommand } from './commands';
+import { joinPath } from './util';
 
 export class WelcomePanel {
 	public static activate(ctx: vscode.ExtensionContext, goCtx: GoExtensionContext) {
@@ -247,18 +247,6 @@ function getNonce() {
 		text += possible.charAt(Math.floor(Math.random() * possible.length));
 	}
 	return text;
-}
-
-function joinPath(uri: vscode.Uri, ...pathFragment: string[]): vscode.Uri {
-	// Reimplementation of
-	// https://github.com/microsoft/vscode/blob/b251bd952b84a3bdf68dad0141c37137dac55d64/src/vs/base/common/uri.ts#L346-L357
-	// with Node.JS path. This is a temporary workaround for https://github.com/eclipse-theia/theia/issues/8752.
-	if (!uri.path) {
-		throw new Error('[UriError]: cannot call joinPaths on URI without path');
-	}
-	return uri.with({
-		path: vscode.Uri.file(path.join(uri.fsPath, ...pathFragment)).path
-	});
 }
 
 function showGoWelcomePage() {


### PR DESCRIPTION
This PR adds two new commands to the VS Code extension for starting and stopping `gnodev` development server. 

The extension also takes care of displaying `Gnoweb` in one of the ways below (configurable in the settings):
	- current: Uses the current active panel
	- beside: Creates and uses a new panel beside the current one
    - external: Opens in external browser (Firefox, Chrome, etc.)
    - none: Runs in background without displaying `Gnoweb`


Another setting allows users to pass additional flags to `gnodev`.

The json logs from gnodev are parsed and displayed cleanly in the output tab of VSCode.